### PR TITLE
Fix termination issue with `wordlist` argument.

### DIFF
--- a/src/cli/interface.rs
+++ b/src/cli/interface.rs
@@ -13,7 +13,7 @@ pub fn banner() {
 
 #[derive(Args, Debug, Clone)]
 pub struct DictionaryArgs {
-    /// Path to the pasword wordlist.
+    /// Path to the password wordlist.
     pub wordlist: String,
 }
 

--- a/src/core/production/custom_query.rs
+++ b/src/core/production/custom_query.rs
@@ -85,14 +85,14 @@ impl CustomQuery {
 }
 
 impl Producer for CustomQuery {
-    fn next(&mut self) -> Option<Vec<u8>> {
+    fn next(&mut self) -> Result<Option<Vec<u8>>, String> {
         let num = self.inner.next();
         match num {
             Some(value) => {
                 let full_number = format!("{:0>width$}", value, width = self.min_digits);
-                Some(format!("{}{}{}", self.prefix, full_number, self.suffix).into_bytes())
+                Ok(Some(format!("{}{}{}", self.prefix, full_number, self.suffix).into_bytes()))
             }
-            None => None,
+            None => Ok(None),
         }
     }
 

--- a/src/core/production/dates.rs
+++ b/src/core/production/dates.rs
@@ -44,14 +44,14 @@ impl DateProducer {
 }
 
 impl Producer for DateProducer {
-    fn next(&mut self) -> Option<Vec<u8>> {
+    fn next(&mut self) -> Result<Option<Vec<u8>>, String> {
         let next = self.inner.next();
         match next {
             Some(datemonth) => {
                 let password = format!("{}{}", datemonth, self.year).into_bytes();
-                Some(password)
+                Ok(Some(password))
             }
-            None => None,
+            None => Ok(None),
         }
     }
 

--- a/src/core/production/dictionary.rs
+++ b/src/core/production/dictionary.rs
@@ -38,13 +38,14 @@ impl LineProducer {
 }
 
 impl Producer for LineProducer {
-    fn next(&mut self) -> Option<Vec<u8>> {
+    fn next(&mut self) -> Result<Option<Vec<u8>>, String> {
         let mut buffer = String::new();
         match self.inner.read_line(&mut buffer) {
-            Ok(_) => Some(buffer.into_bytes()),
+            Ok(line) if line == 0 => Ok(None),
+            Ok(_) => Ok(Some(buffer.into_bytes())),
             Err(err) => {
                 debug!("Unable to read from reader: {}", err);
-                None
+                Err(String::from("Error reading from wordlist file."))
             }
         }
     }

--- a/src/core/production/mod.rs
+++ b/src/core/production/mod.rs
@@ -1,5 +1,5 @@
 pub trait Producer {
-    fn next(&mut self) -> Option<Vec<u8>>;
+    fn next(&mut self) -> Result<Option<Vec<u8>>, String>;
     /// Used for measuring progress. Reflects the number of passwords this producer can produce
     fn size(&self) -> usize;
 }

--- a/src/core/production/number_ranges.rs
+++ b/src/core/production/number_ranges.rs
@@ -17,14 +17,14 @@ impl RangeProducer {
 }
 
 impl Producer for RangeProducer {
-    fn next(&mut self) -> Option<Vec<u8>> {
+    fn next(&mut self) -> Result<Option<Vec<u8>>, String> {
         let next = self.inner.next();
         match next {
             Some(number) => {
                 let data = format!("{:0>width$}", number, width = self.padding_len).into_bytes();
-                Some(data)
+                Ok(Some(data))
             }
-            None => None,
+            None => Ok(None),
         }
     }
 


### PR DESCRIPTION
The application did not terminate upon consuming the entire `wordlist` due to the behavior of `read_line()` at EOF (it returns 0). This was resolved by enhancing the match statement in the `next()` method of the `LineProducer`. As a consequence, the return type of the `next()` function in the `Producer` trait was adjusted.