### PR TITLE
Trim newline char from lines read from file input.

### DIFF
--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -95,6 +95,10 @@ pub fn crack_file(
             println!("Error Occurred: {msg}");
         }
 
+        if let Some(msg) = producer.error_msg() {
+            info!("{}", msg);
+        }
+
         match success {
             Some(password) => {
                 info!(

--- a/src/core/production/dictionary.rs
+++ b/src/core/production/dictionary.rs
@@ -42,7 +42,13 @@ impl Producer for LineProducer {
         let mut buffer = String::new();
         match self.inner.read_line(&mut buffer) {
             Ok(line) if line == 0 => Ok(None),
-            Ok(_) => Ok(Some(buffer.into_bytes())),
+            Ok(_) => {
+                // read_line() returns a String that ends with a newline char unless it is the
+                // last line of the file.
+                let mut bytes = buffer.into_bytes();
+                if bytes.last() == Some(&b'\n') { bytes.pop(); }
+                Ok(Some(bytes.to_vec()))
+            }
             Err(err) => {
                 debug!("Unable to read from reader: {}", err);
                 Err(String::from("Error reading from wordlist file."))

--- a/src/core/production/mod.rs
+++ b/src/core/production/mod.rs
@@ -2,6 +2,9 @@ pub trait Producer {
     fn next(&mut self) -> Result<Option<Vec<u8>>, String>;
     /// Used for measuring progress. Reflects the number of passwords this producer can produce
     fn size(&self) -> usize;
+
+    /// Returns an error message if one occurred during processing.
+    fn error_msg(&self) ->Option<String> { None }
 }
 
 /// Producers that handle dictionary-style attacks


### PR DESCRIPTION
The application did not remove the newline character returned by the read_line function. This led to incorrect password comparisons when using the `wordlist` argument.

Note: If the password legitimately ends with a newline character (which should be rare) and it is the last line in the file and the terminating newline, then this change could potentially remove a valid newline character.