### PR TITLE
Wordlist line is not valid UTF-8 handling.

### DIFF
--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -101,10 +101,24 @@ pub fn crack_file(
 
         match success {
             Some(password) => {
-                info!(
-                    "Success! Found password: {}",
-                    String::from_utf8_lossy(&password)
-                )
+                match std::str::from_utf8(&password) {
+                    Ok(password) => {
+                        info!(
+                            "Success! Found password: {}",
+                            password
+                        )
+                    }
+                    Err(_) => {
+                        let hex_string: String = password.iter()
+                            .map(|b| format!("{:02x}", b))
+                            .collect::<Vec<String>>()
+                            .join(" ");
+                        info!(
+                            "Success! Found password, but it contains invalid UTF-8 characters. Displaying as hex: {}",
+                            hex_string
+                        )
+                    }
+                }
             }
             None => {
                 info!("Failed to crack file...")
@@ -112,7 +126,7 @@ pub fn crack_file(
         }
         // We cannot use the ? operator here due to size constraints
     })
-    .expect("Something went wrong when cracking file");
+        .expect("Something went wrong when cracking file");
 
     Ok(())
 }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -95,6 +95,10 @@ pub fn crack_file(
             println!("Error Occurred: {msg}");
         }
 
+        if let Some(msg) = producer.error_msg() {
+            info!("{}", msg);
+        }
+
         match success {
             Some(password) => {
                 info!(

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -95,10 +95,6 @@ pub fn crack_file(
             println!("Error Occurred: {msg}");
         }
 
-        if let Some(msg) = producer.error_msg() {
-            info!("{}", msg);
-        }
-
         match success {
             Some(password) => {
                 match std::str::from_utf8(&password) {

--- a/src/core/production/dictionary.rs
+++ b/src/core/production/dictionary.rs
@@ -8,7 +8,6 @@ use super::Producer;
 pub struct LineProducer {
     inner: Box<dyn BufRead>,
     size: usize,
-    invalid_lines: usize,
 }
 
 impl LineProducer {
@@ -34,7 +33,6 @@ impl LineProducer {
         Self {
             inner: Box::from(reader),
             size: lines,
-            invalid_lines: 0,
         }
     }
 }
@@ -58,17 +56,5 @@ impl Producer for LineProducer {
 
     fn size(&self) -> usize {
         self.size
-    }
-
-    fn error_msg(&self) -> Option<String> {
-        if self.invalid_lines == 0 {
-            None
-        } else {
-            Some(format!(
-                "Warning: {} invalid line{} found in wordlist file.",
-                self.invalid_lines,
-                if self.invalid_lines == 1 {""} else {"s"}
-            ))
-        }
     }
 }

--- a/src/core/production/dictionary.rs
+++ b/src/core/production/dictionary.rs
@@ -43,13 +43,11 @@ impl LineProducer {
 impl Producer for LineProducer {
     fn next(&mut self) -> Result<Option<Vec<u8>>, String> {
         loop {
-            let mut buffer = String::new();
-            match self.inner.read_line(&mut buffer) {
+            let mut bytes = Vec::new();
+            match self.inner.read_until(b'\n', &mut bytes) {
                 Ok(line) if line == 0 => return Ok(None),
                 Ok(_) => {
-                    // read_line() returns a String that ends with a newline char unless it is the
-                    // last line of the file.
-                    let mut bytes = buffer.into_bytes();
+                    // read_until() ends with a newline char unless it is the last line of the file.
                     if bytes.last() == Some(&b'\n') { bytes.pop(); }
                     return Ok(Some(bytes))
                 }

--- a/src/core/production/dictionary.rs
+++ b/src/core/production/dictionary.rs
@@ -42,7 +42,13 @@ impl Producer for LineProducer {
         let mut buffer = String::new();
         match self.inner.read_line(&mut buffer) {
             Ok(line) if line == 0 => Ok(None),
-            Ok(_) => Ok(Some(buffer.into_bytes())),
+            Ok(_) => {
+                // read_line() returns a String that ends with a newline char unless it is the
+                // last line of the file.
+                let mut bytes = buffer.into_bytes();
+                if bytes.last() == Some(&b'\n') { bytes.pop(); }
+                Ok(Some(bytes.to_vec()))
+            }
             Err(err) => {
                 debug!("Unable to read from reader: {}", err);
                 Err(String::from("Error reading from wordlist file."))

--- a/src/core/production/mod.rs
+++ b/src/core/production/mod.rs
@@ -2,9 +2,6 @@ pub trait Producer {
     fn next(&mut self) -> Result<Option<Vec<u8>>, String>;
     /// Used for measuring progress. Reflects the number of passwords this producer can produce
     fn size(&self) -> usize;
-
-    /// Returns an error message if one occurred during processing.
-    fn error_msg(&self) ->Option<String> { None }
 }
 
 /// Producers that handle dictionary-style attacks

--- a/src/core/production/mod.rs
+++ b/src/core/production/mod.rs
@@ -2,6 +2,9 @@ pub trait Producer {
     fn next(&mut self) -> Result<Option<Vec<u8>>, String>;
     /// Used for measuring progress. Reflects the number of passwords this producer can produce
     fn size(&self) -> usize;
+
+    /// Returns an error message if one occurred during processing.
+    fn error_msg(&self) ->Option<String> { None }
 }
 
 /// Producers that handle dictionary-style attacks


### PR DESCRIPTION
The application would fail if a wordlist had anything except UTF-8 encoding. Instead, it will now process all lines that are properly UTF-8 encoded and skip other lines. It will also print a warning to the user when it completes, notifying them about the number of skipped lines.