### PR TITLE
Re #10 Create new search type that uses letters and words

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## ℹ️ Introduction
 
-**pdfrip** is a fast multithreaded PDF password cracking utility written in Rust with support for wordlist based dictionary attacks, date and number range bruteforcing, and a custom query builder for password formats.
+**pdfrip** is a fast multithreaded PDF password cracking utility written in Rust with support for wordlist based dictionary attacks, date, number range, and alphanumeric bruteforcing, and a custom query builder for password formats.
 
 <div align="center">
   <table>
@@ -30,6 +30,7 @@
 - **Custom Query Builder:** You can write your own queries like `STRING{69-420}` which would generate and use a wordlist with the full number range.
 - **Date Bruteforce:** You can pass in a year which would bruteforce all 365 days of the year in `DDMMYYYY` format which is a pretty commonly used password format for PDFs.
 - **Number Bruteforce:** Just give a number range like `5000-100000` and it would bruteforce with the whole range.
+- **Default Bruteforce:** Specify a maximum and optionally a minimum length for the password search and all passwords of length 4 up to the specified maximum consisting of letters and numbers (`a-zA-Z0-9`) will be tried
 
 ## Installation
 
@@ -85,13 +86,21 @@ Bruteforce number ranges for the password:
 Bruteforce all dates in a year for the password in `DDMMYYYY` format:
 
     $ pdfrip -f encrypted.pdf date 1999
-    
+
+Bruteforce arbitrary strings of length 4-8:
+
+    $ pdfrip -f encrypted.pdf default-query --max-length 8
+
+Bruteforce arbitrary strings of length 3:
+
+    $ pdfrip -f encrypted.pdf default-query --max-length 3 --min-length 3
+
 Build a custom query to generate a wordlist: (useful when you know the password format)
 
     $ pdfrip -f encrypted.pdf custom-query ALICE{1000-9999}
-    
+
     $ pdfrip -f encrypted.pdf custom-query DOC-ID{0-99}-FILE
-    
+
 Enable preceding zeros for custom queries: (which would make `{10-5000}` to `{0010-5000}` matching the end range's digits)
 
     $ pdfrip -f encrypted.pdf custom-query ALICE{10-9999} --add-preceding-zeros

--- a/src/cli/interface.rs
+++ b/src/cli/interface.rs
@@ -37,6 +37,15 @@ pub struct CustomQueryArgs {
 }
 
 #[derive(Args, Debug, Clone)]
+pub struct DefaultQueryArgs {
+    #[clap(long, default_value_t = 4)]
+    pub min_length: u32,
+
+    #[clap(long)]
+    pub max_length: u32,
+}
+
+#[derive(Args, Debug, Clone)]
 pub struct DateArgs {
     #[clap(long, short)]
     pub year: usize,
@@ -48,6 +57,7 @@ pub enum Method {
     Range(RangeArgs),
     CustomQuery(CustomQueryArgs),
     Date(DateArgs),
+    DefaultQuery(DefaultQueryArgs),
 }
 
 // Let's use Clap to ensure our program can only be called with valid parameter combinations

--- a/src/core/production/default_query.rs
+++ b/src/core/production/default_query.rs
@@ -1,0 +1,68 @@
+use super::Producer;
+
+pub struct DefaultQuery {
+    min_length: u32,
+    max_length: u32,
+    current:Vec<u8>,
+    char_set: Vec<u8>,
+    rolled: bool,
+}
+
+impl DefaultQuery {
+    pub fn new(max_length: u32, min_length: u32) -> Self {
+        let mut char_set: Vec<u8> = (b'0'..=b'9').chain(b'a'..=b'z').chain(b'A'..=b'Z').collect();
+        char_set.sort();
+        Self{max_length: max_length, min_length: min_length,
+            current: vec!(char_set[0]; min_length.try_into().unwrap()), char_set: char_set, rolled: false}
+    }
+}
+
+impl Producer for DefaultQuery {
+    fn next(&mut self) -> Result<Option<Vec<u8>>, String> {
+        let mut next = self.current.clone();
+        let mut stopped = false;
+        for i in 0..next.len() {
+            let spot = match self.char_set.binary_search(&next[i]) {
+                Ok(spot) => spot,
+                Err(_) => return Err("Couldn't find character in character set".to_string()),
+            };
+            if spot >= self.char_set.len()-1 {
+                next[i] = self.char_set[0];
+            } else {
+                next[i] = self.char_set[spot+1];
+                stopped = true;
+                break;
+            }
+        }
+        if !stopped {
+            // We rolled every digit to every character, now we need to add a new character
+            next.insert(0, self.char_set[0]);
+            if next.len() > self.max_length.try_into().unwrap() {
+                if self.rolled {
+                    return Err("Out of elements".to_string());
+                } else {
+                    self.rolled = true;
+                    // For debugging
+                    //match String::from_utf8(self.current.clone()) {
+                        //Ok(val)=>println!("Trying {}", val), _=>{}
+                    //};
+                    return Ok(Some(self.current.clone()));
+                }
+            }
+        }
+        let return_value = std::mem::replace(&mut self.current, next);
+        // For debugging and making sure all values are tried
+        //match String::from_utf8(return_value.clone()) {
+            //Ok(val)=>println!("Trying {}", val), _=>{}
+        //};
+        Ok(Some(return_value))
+    }
+
+    fn size(&self) -> usize {
+        let mut ret = 0usize;
+        for len in self.min_length..=self.max_length {
+            ret += self.char_set.len().pow(len);
+        }
+        ret
+    }
+}

--- a/src/core/production/mod.rs
+++ b/src/core/production/mod.rs
@@ -15,3 +15,7 @@ pub mod custom_query;
 
 /// handles creating passwords matching dates in DDMMYYYY format
 pub mod dates;
+
+/// Does a traditional brute-force search through all possible combinations
+/// of letters and numbers
+pub mod default_query;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use pretty_env_logger::env_logger::Env;
 
 use crate::core::cracker::pdf::PDFCracker;
 use crate::core::production::custom_query::CustomQuery;
+use crate::core::production::default_query::DefaultQuery;
 use crate::core::production::dictionary::LineProducer;
 use crate::core::production::Producer;
 
@@ -52,6 +53,10 @@ pub fn main() -> anyhow::Result<()> {
         }
         interface::Method::Date(args) => {
             let producer = DateProducer::new(args.year);
+            Box::from(producer)
+        }
+        interface::Method::DefaultQuery(args) => {
+            let producer = DefaultQuery::new(args.max_length, args.min_length);
             Box::from(producer)
         }
     };


### PR DESCRIPTION
Hitherto, searches were limited to numeric searches or dictionary searches. The herein added search does a traditional brute-force search using a currently-hardcoded character-set. The characters in the characterset are a-zA-Z0-9, so passwords like EatMy59Pandas will be covered. The search strategy takes a maximum length and uses four characters as a minimum length.