### PR TITLE
Reimplement src/core/engine.rs to fix race conditions

### DIFF
--- a/src/core/cracker.rs
+++ b/src/core/cracker.rs
@@ -1,15 +1,8 @@
-/// We require cracker implementations to support being sent between threads.
-pub trait Cracker: Sync + Send{
-    /// Attempt to crack the cryptography using the password, return true on success.
-    fn attempt(&self, password: &[u8]) -> bool;
-}
-
 pub mod pdf {
     use std::{fs, io};
 
     use pdf::file::FileOptions;
 
-    use super::Cracker;
     #[derive(Clone)]
     pub struct PDFCracker(Vec<u8>);
 
@@ -20,8 +13,9 @@ pub mod pdf {
         }
     }
 
-    impl Cracker for PDFCracker {
-        fn attempt(&self, password: &[u8]) -> bool {
+    impl PDFCracker {
+        /// Attempt to crack the cryptography using the password, return true on success.
+        pub fn attempt(&self, password: &[u8]) -> bool {
             FileOptions::cached()
                 .password(password)
                 .load(self.0.as_ref())

--- a/src/core/cracker.rs
+++ b/src/core/cracker.rs
@@ -1,5 +1,5 @@
 /// We require cracker implementations to support being sent between threads.
-pub trait Cracker: Sync + Send {
+pub trait Cracker: Sync + Send{
     /// Attempt to crack the cryptography using the password, return true on success.
     fn attempt(&self, password: &[u8]) -> bool;
 }
@@ -10,7 +10,7 @@ pub mod pdf {
     use pdf::file::FileOptions;
 
     use super::Cracker;
-
+    #[derive(Clone)]
     pub struct PDFCracker(Vec<u8>);
 
     impl PDFCracker {

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -4,7 +4,7 @@
 const BUFFER_SIZE: usize = 200;
 
 use crossbeam::{
-    channel::{Receiver, Sender},
+    channel::{Receiver, Sender, TryRecvError},
     thread,
 };
 use indicatif::ProgressBar;
@@ -13,10 +13,6 @@ use crate::core::production::Producer;
 
 use super::cracker::Cracker;
 
-enum Message {
-    Password(Vec<u8>),
-    Die,
-}
 
 pub fn crack_file(
     no_workers: usize,
@@ -24,7 +20,7 @@ pub fn crack_file(
     mut producer: Box<dyn Producer>,
 ) -> anyhow::Result<()> {
     // Spin up workers
-    let (sender, r): (Sender<Message>, Receiver<Message>) =
+    let (sender, r): (Sender<Vec<u8>>, Receiver<Vec<u8>>) =
         crossbeam::channel::bounded(BUFFER_SIZE);
 
     let (success_sender, success_reader) = crossbeam::channel::unbounded::<Vec<u8>>();
@@ -33,16 +29,11 @@ pub fn crack_file(
         for _ in 0..no_workers {
             s.builder()
                 .spawn(|_| {
-                    while let Ok(message) = r.recv() {
-                        match message {
-                            Message::Password(password) => {
-                                if cracker.attempt(&password) {
-                                    // inform main thread we found a good password then die
-                                    let _ = success_sender.send(password);
-                                    return;
-                                }
-                            }
-                            Message::Die => return,
+                    while let Ok(password) = r.recv() {
+                        if cracker.attempt(&password) {
+                            // inform main thread we found a good password then die
+                            success_sender.send(password).unwrap_or_default();
+                            return;
                         }
                     }
                 })
@@ -50,52 +41,75 @@ pub fn crack_file(
         }
 
         info!("Starting crack...");
+
         let mut success = None;
-        let mut error_message = None;
 
         let progress_bar = ProgressBar::new(producer.size() as u64);
         progress_bar.set_draw_delta(1000);
 
         loop {
-            // Check if any thread succeeded..
             match success_reader.try_recv() {
                 Ok(password) => {
                     success = Some(password);
                     break;
-                }
-                Err(_) => {
-                    // They have not finished yet. Send some passwords
-                    match producer.next() {
-                        Ok(Some(password)) => {
-                            // Ignore any errors in case the reading threads have exited
-                            let _ = sender.send(Message::Password(password));
-                            progress_bar.inc(1);
-                        }
-                        Ok(None) => {
-                            // Out of passwords, exit loop
+                },
+                Err(e) => {
+                    match e {
+                        TryRecvError::Empty => {
+                            // This is fine *lit*
+                        },
+                        TryRecvError::Disconnected => {
+                            // All threads have died. Wtf?
+                            // let's just report an error and break
+                            error!("All workers have exited prematurely, cannot continue operations");
                             break;
+                        },
+                    }
+                },
+            }
+
+                match producer.next() {
+                    Ok(Some(password)) => {
+                        if let Err(e) = sender.send(password) {
+                            // This should only happen if their reciever is closed.
+                            error!("unable to send next password: {}", String::from_utf8_lossy(&e.0));
                         }
-                        Err(error_msg) => {
-                            // Error occurred
-                            error_message = Some(error_msg);
-                            break;
-                        }
+                        progress_bar.inc(1);
+                    }
+                    Ok(None) => {
+                        // Out of passwords, stop loop
+                        break;
+                    }
+                    Err(error_msg) => {
+                        error!("error occured while sending: {error_msg}");
+                        break;
                     }
                 }
-            };
+            
         }
+
+
+        // Ensure any threads that are still running will eventually exit
+        drop(sender);
+
+        let found_password = match success {
+            Some(result) => Some(result),
+            None => {
+                match success_reader.recv(){
+                    Ok(result) => Some(result),
+                    Err(e) => {
+                        // Channel is empty and disconnected, i.e. all threads have exited
+                        // and none found the password
+                        debug!("{}", e);
+                        None
+                    },
+                }
+            },
+        };
+
         progress_bar.finish();
-        // Kill any threads that are still running
-        for _ in 0..no_workers {
-            // Ignore any errors in case the threads have exited
-            let _ = sender.send(Message::Die);
-        }
 
-        if let Some(msg) = error_message {
-            println!("Error Occurred: {msg}");
-        }
-
-        match success {
+        match found_password {
             Some(password) => {
                 match std::str::from_utf8(&password) {
                     Ok(password) => {

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -8,7 +8,7 @@ use indicatif::ProgressBar;
 
 use crate::core::production::Producer;
 
-use super::cracker::{pdf::PDFCracker, Cracker};
+use super::cracker::pdf::PDFCracker;
 
 pub fn crack_file(
     no_workers: usize,

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -3,140 +3,145 @@
 // so the queue won't be consumed before the producer has time to wake up
 const BUFFER_SIZE: usize = 200;
 
-use crossbeam::{
-    channel::{Receiver, Sender, TryRecvError},
-    thread,
-};
+use crossbeam::channel::{Receiver, Sender, TryRecvError};
 use indicatif::ProgressBar;
 
 use crate::core::production::Producer;
 
-use super::cracker::Cracker;
+use super::cracker::{pdf::PDFCracker, Cracker};
 
+enum Message {
+    Password(Vec<u8>),
+    Die,
+}
 
 pub fn crack_file(
     no_workers: usize,
-    cracker: Box<dyn Cracker>,
+    cracker: PDFCracker,
     mut producer: Box<dyn Producer>,
 ) -> anyhow::Result<()> {
     // Spin up workers
-    let (sender, r): (Sender<Vec<u8>>, Receiver<Vec<u8>>) =
-        crossbeam::channel::bounded(BUFFER_SIZE);
+    let (sender, r): (Sender<Message>, Receiver<_>) = crossbeam::channel::bounded(BUFFER_SIZE);
 
     let (success_sender, success_reader) = crossbeam::channel::unbounded::<Vec<u8>>();
+    let mut handles = vec![];
 
-    thread::scope(|s| {
-        for _ in 0..no_workers {
-            s.builder()
-                .spawn(|_| {
-                    while let Ok(password) = r.recv() {
-                        if cracker.attempt(&password) {
+    for _ in 0..no_workers {
+        let success = success_sender.clone();
+        let r2 = r.clone();
+        let c2 = cracker.clone();
+        let id = std::thread::spawn(move || {
+            while let Ok(message) = r2.recv() {
+                match message {
+                    Message::Password(passwd) => {
+                        if c2.attempt(&passwd) {
                             // inform main thread we found a good password then die
-                            success_sender.send(password).unwrap_or_default();
+                            success.send(passwd).unwrap_or_default();
                             return;
                         }
                     }
-                })
-                .unwrap();
-        }
-
-        info!("Starting crack...");
-
-        let mut success = None;
-
-        let progress_bar = ProgressBar::new(producer.size() as u64);
-        progress_bar.set_draw_delta(1000);
-
-        loop {
-            match success_reader.try_recv() {
-                Ok(password) => {
-                    success = Some(password);
-                    break;
-                },
-                Err(e) => {
-                    match e {
-                        TryRecvError::Empty => {
-                            // This is fine *lit*
-                        },
-                        TryRecvError::Disconnected => {
-                            // All threads have died. Wtf?
-                            // let's just report an error and break
-                            error!("All workers have exited prematurely, cannot continue operations");
-                            break;
-                        },
+                    Message::Die => {
+                        return;
                     }
-                },
+                }
             }
+        });
+        handles.push(id);
+    }
+    // Drop our ends
+    drop(r);
+    drop(success_sender);
 
-                match producer.next() {
-                    Ok(Some(password)) => {
-                        if let Err(e) = sender.send(password) {
-                            // This should only happen if their reciever is closed.
-                            error!("unable to send next password: {}", String::from_utf8_lossy(&e.0));
-                        }
-                        progress_bar.inc(1);
+    info!("Starting crack...");
+
+    let mut success = None;
+
+    let progress_bar = ProgressBar::new(producer.size() as u64);
+    progress_bar.set_draw_delta(1000);
+
+    loop {
+        match success_reader.try_recv() {
+            Ok(password) => {
+                success = Some(password);
+                break;
+            }
+            Err(e) => {
+                match e {
+                    TryRecvError::Empty => {
+                        // This is fine *lit*
                     }
-                    Ok(None) => {
-                        // Out of passwords, stop loop
-                        break;
-                    }
-                    Err(error_msg) => {
-                        error!("error occured while sending: {error_msg}");
+                    TryRecvError::Disconnected => {
+                        // All threads have died. Wtf?
+                        // let's just report an error and break
+                        error!("All workers have exited prematurely, cannot continue operations");
                         break;
                     }
                 }
-            
+            }
         }
 
-
-        // Ensure any threads that are still running will eventually exit
-        drop(sender);
-
-        let found_password = match success {
-            Some(result) => Some(result),
-            None => {
-                match success_reader.recv(){
-                    Ok(result) => Some(result),
-                    Err(e) => {
-                        // Channel is empty and disconnected, i.e. all threads have exited
-                        // and none found the password
-                        debug!("{}", e);
-                        None
-                    },
+        match producer.next() {
+            Ok(Some(password)) => {
+                if let Err(_) = sender.send(Message::Password(password)) {
+                    // This should only happen if their reciever is closed.
+                    error!("unable to send next password since channel is closed");
                 }
-            },
-        };
+                progress_bar.inc(1);
+            }
+            Ok(None) => {
+                trace!("out of passwords, exiting loop");
+                break;
+            }
+            Err(error_msg) => {
+                error!("error occured while sending: {error_msg}");
+                break;
+            }
+        }
+    }
 
-        progress_bar.finish();
+    // Ensure any threads that are still running will eventually exit
+    for _ in 0..no_workers {
+        sender.send(Message::Die).unwrap_or_default();
+    }
 
-        match found_password {
-            Some(password) => {
-                match std::str::from_utf8(&password) {
-                    Ok(password) => {
-                        info!(
-                            "Success! Found password: {}",
-                            password
-                        )
-                    }
-                    Err(_) => {
-                        let hex_string: String = password.iter()
-                            .map(|b| format!("{:02x}", b))
-                            .collect::<Vec<String>>()
-                            .join(" ");
-                        info!(
+    let found_password = match success {
+        Some(result) => Some(result),
+        None => {
+            match success_reader.recv() {
+                Ok(result) => Some(result),
+                Err(e) => {
+                    // Channel is empty and disconnected, i.e. all threads have exited
+                    // and none found the password
+                    debug!("{}", e);
+                    None
+                }
+            }
+        }
+    };
+
+    progress_bar.finish();
+
+    match found_password {
+        Some(password) => match std::str::from_utf8(&password) {
+            Ok(password) => {
+                info!("Success! Found password: {}", password)
+            }
+            Err(_) => {
+                let hex_string: String = password
+                    .iter()
+                    .map(|b| format!("{:02x}", b))
+                    .collect::<Vec<String>>()
+                    .join(" ");
+                info!(
                             "Success! Found password, but it contains invalid UTF-8 characters. Displaying as hex: {}",
                             hex_string
                         )
-                    }
-                }
             }
-            None => {
-                info!("Failed to crack file...")
-            }
+        },
+        None => {
+            info!("Failed to crack file...")
         }
-        // We cannot use the ? operator here due to size constraints
-    })
-        .expect("Something went wrong when cracking file");
+    }
 
     Ok(())
 }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -3,6 +3,8 @@
 // so the queue won't be consumed before the producer has time to wake up
 const BUFFER_SIZE: usize = 200;
 
+use std::sync::Arc;
+
 use crossbeam::channel::{Receiver, Sender, TryRecvError};
 use indicatif::ProgressBar;
 
@@ -20,11 +22,12 @@ pub fn crack_file(
 
     let (success_sender, success_reader) = crossbeam::channel::unbounded::<Vec<u8>>();
     let mut handles = vec![];
+    let cracker_handle = Arc::from(cracker);
 
     for _ in 0..no_workers {
         let success = success_sender.clone();
         let r2 = r.clone();
-        let c2 = cracker.clone();
+        let c2 = cracker_handle.clone();
         let id: std::thread::JoinHandle<()> = std::thread::spawn(move || {
             while let Ok(passwd) = r2.recv() {
                 if c2.attempt(&passwd) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,8 +59,11 @@ pub fn main() -> anyhow::Result<()> {
         }
     };
 
-    engine::crack_file(cli.number_of_threads, 
-        PDFCracker::from_file(&cli.filename).context(format!("path: {}", cli.filename))?, producer)?;
+    engine::crack_file(
+        cli.number_of_threads,
+        PDFCracker::from_file(&cli.filename).context(format!("path: {}", cli.filename))?,
+        producer,
+    )?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ pub fn main() -> anyhow::Result<()> {
         }
     };
 
-    engine::crack_file(cli.number_of_threads, Box::new(cracker), producer)?;
+    engine::crack_file(cli.number_of_threads, cracker, producer)?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,8 +26,6 @@ pub fn main() -> anyhow::Result<()> {
     // print a banner to look cool!
     interface::banner();
     let cli = interface::args();
-    let cracker =
-        PDFCracker::from_file(&cli.filename).context(format!("path: {}", cli.filename))?;
 
     let producer: Box<dyn Producer> = match cli.subcommand {
         interface::Method::Wordlist(args) => {
@@ -61,7 +59,8 @@ pub fn main() -> anyhow::Result<()> {
         }
     };
 
-    engine::crack_file(cli.number_of_threads, cracker, producer)?;
+    engine::crack_file(cli.number_of_threads, 
+        PDFCracker::from_file(&cli.filename).context(format!("path: {}", cli.filename))?, producer)?;
 
     Ok(())
 }


### PR DESCRIPTION
Addresses #14 
Pseudocode for the new engine algorithm:

```
            Start threads, they read until they get a RecvError::Disconnected 
                If successful, try the password. Send results if success
            
            Main thread:
                Loop:
                    * try_recv
                        if successful, break
                        if Disconnected, all threads have died. Exit
                        if Empty, proceed.

                    * producer:
                        if password generator is empty, close sender and break
                        else send next password in buffer. 
                            if Disconnected, break
                
                Close password sender.
                Block on result receiever.
                    If successfully received password: good
                    if RecvError::Disconnected, report failure. We did not find the password :(
```
