### PR TITLE
Added Build+test step for multiple OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+on:
+  push:
+  pull_request:
+
+name: CI
+jobs:
+  build_and_test:
+    name: OS Test
+    strategy:
+      fail-fast: false
+      matrix:
+        rust-version:
+          - nightly
+          - stable
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust-version }}
+      - name: Build
+        run: cargo build --all --verbose
+      - name: Test
+        run: cargo test --all --verbose
+  lint:
+    name: Clippy and fmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - name: Check formatting
+        run: cargo fmt --check
+      - name: Check for clippy lints
+        run: cargo clippy


### PR DESCRIPTION
It'd be useful to try and build + run our tests on more platforms than just linux. 

This PR adds a workflow  where we build and run our tests on windows, linux (ubuntu) and macos. We test both the stable and nightly toolchain.

Additionally it also runs checks with cargo fmt and clippy, which could help keep this project clean in the future.

Note that I did not bother ensuring the formatting/clippy tests pass since that would bloat this PR imo. Finally keep in mind that some clippy lints aren't perfect, so PRs should not be denied simply because of it failing a clippy lint.