### PR TITLE
Inline bits of pdf crate for better performance

### DIFF
--- a/crates/cracker/Cargo.toml
+++ b/crates/cracker/Cargo.toml
@@ -9,3 +9,4 @@ authors.workspace = true
 [dependencies]
 log.workspace = true
 pdf.workspace = true
+anyhow.workspace = true

--- a/crates/cracker/src/lib.rs
+++ b/crates/cracker/src/lib.rs
@@ -1,6 +1,11 @@
-use std::{fs, io};
+use std::{fs, io, cell::RefCell, sync::Arc};
+use std::collections::hash_map::HashMap;
 
-use pdf::file::FileOptions;
+use anyhow::anyhow;
+use pdf::PdfError;
+use pdf::any::AnySync;
+use pdf::file::{Cache, Storage};
+use pdf::object::{ParseOptions, PlainRef};
 
 #[derive(Clone)]
 pub struct PDFCracker(Vec<u8>);
@@ -12,12 +17,57 @@ impl PDFCracker {
     }
 }
 
-impl PDFCracker {
+type ObjectCache = SimpleCache<Result<AnySync, Arc<PdfError>>>;
+type StreamCache = SimpleCache<Result<Arc<[u8]>, Arc<PdfError>>>;
+
+pub struct PDFCrackerState(
+    Storage<Vec<u8>, ObjectCache, StreamCache>
+);
+
+impl PDFCrackerState {
+    /// Init `pdf::file::Storage` so we can reuse it on each `attempt`.
+    pub fn from_cracker(pdf_file: &PDFCracker) -> anyhow::Result<Self> {
+        let res = Storage::with_cache(
+            pdf_file.0.clone(),
+            ParseOptions::strict(),
+            SimpleCache::new(),
+            SimpleCache::new(),
+        );
+
+        match res {
+            Ok(storage) => Ok(Self(storage)),
+            Err(err) => Err(anyhow!(err).context("Failed to init cracker")),
+        }
+    }
+
     /// Attempt to crack the cryptography using the password, return true on success.
-    pub fn attempt(&self, password: &[u8]) -> bool {
-        FileOptions::cached()
-            .password(password)
-            .load(self.0.as_ref())
+    pub fn attempt(&mut self, password: &[u8]) -> bool {
+        self.0.load_storage_and_trailer_password(password)
             .is_ok()
+    }
+}
+
+/// Single-threaded adapter to use `HashMap` as a `pdf::file::Cache`.
+struct SimpleCache<T>(
+    RefCell<HashMap<PlainRef, T>>
+);
+
+impl<T: Clone> SimpleCache<T> {
+    fn new() -> Self {
+        Self(RefCell::new(HashMap::new()))
+    }
+}
+
+impl<T: Clone> Cache<T> for SimpleCache<T> {
+    fn get_or_compute(&self, key: PlainRef, compute: impl FnOnce() -> T) -> T {
+        let mut hash = self.0.borrow_mut();
+        match hash.get(&key) {
+            Some(value) => value.clone(),
+            None => {
+                let value = compute();
+                hash.insert(key, value.clone());
+                value
+            }
+        }
     }
 }


### PR DESCRIPTION
Hello and thank you for this project, it helped me A LOT recently.

I was in a need to restore passwords for multiple PDF documents, so performance was really important. It occurs that sharing single `pdf::file::Storage` between attempts in a single thread results in a noticeable speedup.

Cracking one of the example files on my machine:
  - 6113 vs 2269 attempts/s for single thread
  - 14315 vs 6095 attempts/s for four threads

#### Single thread
```bash
user@zen ~/t/pdfrip (inline-pdf-storage)> cargo run --release -- -n 1 -f examples/default-query-1.pdf range 1 1000000
 2024-04-22T17:23:26.430Z INFO  engine > Starting password cracking job...
  [00:02:43] [████████████████████████████████████████]  999999/999999  100% 6113/s ETA: 0s
 2024-04-22T17:26:10.043Z INFO  cli_interface > Failed to crack file...
```

```bash
user@zen ~/t/pdfrip (main) [1]> cargo run --release -- -n 1 -f examples/default-query-1.pdf range 1 1000000
 2024-04-22T17:36:11.308Z INFO  engine > Starting password cracking job...
  [00:07:20] [████████████████████████████████████████]  999999/999999  100% 2269/s ETA: 0s
 2024-04-22T17:43:32.091Z INFO  cli_interface > Failed to crack file...
```

#### Four threads
```bash
user@zen ~/t/pdfrip (inline-pdf-storage) [1]> cargo run --release -- -n 4 -f examples/default-query-1.pdf range 1 1000000
 2024-04-22T17:28:08.219Z INFO  engine > Starting password cracking job...
  [00:01:09] [████████████████████████████████████████]  999999/999999  100% 14315/s ETA: 0s
 2024-04-22T17:29:18.090Z INFO  cli_interface > Failed to crack file...
```

```bash
user@zen ~/t/pdfrip (main) [1]> cargo run --release -- -n 4 -f examples/default-query-1.pdf range 1 1000000
 2024-04-22T17:32:44.111Z INFO  engine > Starting password cracking job...
  [00:02:44] [████████████████████████████████████████]  999999/999999  100% 6095/s ETA: 0s
 2024-04-22T17:35:28.198Z INFO  cli_interface > Failed to crack file...
```