### PR TITLE
address #49

### DIFF
--- a/crates/cli-interface/src/lib.rs
+++ b/crates/cli-interface/src/lib.rs
@@ -94,7 +94,7 @@ pub fn entrypoint(args: Arguments) -> Result {
     match res {
         Some(password) => match std::str::from_utf8(&password) {
             Ok(password) => {
-                info!("Success! Found password: {}", password)
+                info!("Success! Found password, displaying as UTF-8: '{}'", password)
             }
             Err(_) => {
                 let hex_string: String = password
@@ -103,7 +103,7 @@ pub fn entrypoint(args: Arguments) -> Result {
                     .collect::<Vec<String>>()
                     .join(" ");
                 info!(
-                            "Success! Found password, but it contains invalid UTF-8 characters. Displaying as hex: {}",
+                            "Success! Found password, but it contains invalid UTF-8 characters. Displaying as hex: '{}'",
                             hex_string
                         )
             }


### PR DESCRIPTION
Enclose the password within singleticks to aid in visualizing e.g. empty passwords or those consisting of "invisible characters"