### PR TITLE
Updating pdf crate from 0.8.1 to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ cli-interface.path="crates/cli-interface"
 # crates use different major versions causing issues.
 bytecount = "0.6.7"
 log = "0.4.19"
-pdf = "0.8.1"
+pdf = "0.9.0"
 anyhow = "1.0.72"
 indicatif = "0.16.2"
 crossbeam = "0.8.2"

--- a/crates/cracker/src/lib.rs
+++ b/crates/cracker/src/lib.rs
@@ -4,7 +4,7 @@ use std::collections::hash_map::HashMap;
 use anyhow::anyhow;
 use pdf::PdfError;
 use pdf::any::AnySync;
-use pdf::file::{Cache, Storage};
+use pdf::file::{Cache, NoLog, Storage};
 use pdf::object::{ParseOptions, PlainRef};
 
 #[derive(Clone)]
@@ -21,7 +21,7 @@ type ObjectCache = SimpleCache<Result<AnySync, Arc<PdfError>>>;
 type StreamCache = SimpleCache<Result<Arc<[u8]>, Arc<PdfError>>>;
 
 pub struct PDFCrackerState(
-    Storage<Vec<u8>, ObjectCache, StreamCache>
+    Storage<Vec<u8>, ObjectCache, StreamCache, NoLog>
 );
 
 impl PDFCrackerState {
@@ -32,6 +32,7 @@ impl PDFCrackerState {
             ParseOptions::strict(),
             SimpleCache::new(),
             SimpleCache::new(),
+            NoLog
         );
 
         match res {


### PR DESCRIPTION
I was facing a problem when decrrypting a pdf:
```
$ pdfrip -f ~/encrypted.pdf wordlist ~/forPdf.txt         
           .___ _____       .__        
______   __| _// ____\______|__|_____  
\____ \ / __ |\   __\\_  __ \  \____ \ 
|  |_> > /_/ | |  |   |  | \/  |  |_> >
|   __/\____ | |__|   |__|  |__|   __/ 
|__|        \/                 |__|    2.0.1

 2025-02-14T23:09:14.566Z INFO  engine > Starting password cracking job...
thread '<unnamed>' panicked at /Users/adi928/.cargo/registry/src/index.crates.io-6f17d22bba15001f/pdf-0.8.1/src/crypt.rs:290:41:
range end index 128 out of range for slice of length 16
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
[1]    32620 abort      pdfrip -f ~/encrypted.pdf wordlist ~/forPdf.txt
```

Basically, for some reason pdf crate was unable to execute function `key_derivation_owner_password_rc4` and was performing hash.compute on a digest size of 16 with a keySize of 128. I'm don't know if it picked the correct algorithm for decryption since we don't provide that explicitly.

Updating pdf crate version was a shot in the dark and it seemed to have worked for me. 

In order to actually update the crate, I had to add I guess a logging framework as a 5th parameter, which I chose as `NoLog` since I don't know the proper log framework in Rust (this is my first rust push).

Fix working:
```
➜  $ cd target/release 
➜  $ ./pdfrip -f ~/encrypted.pdf wordlist ~/forPdf.txt       
           .___ _____       .__        
______   __| _// ____\______|__|_____  
\____ \ / __ |\   __\\_  __ \  \____ \ 
|  |_> > /_/ | |  |   |  | \/  |  |_> >
|   __/\____ | |__|   |__|  |__|   __/ 
|__|        \/                 |__|    2.0.1

 2025-02-14T23:10:28.415Z INFO  engine > Starting password cracking job...
  [00:00:00] [████████████████████████████████████████]   10000/10000   100% 41711/s ETA: 0s
 2025-02-14T23:10:28.659Z INFO  cli_interface > Failed to crack file...
```