### PR TITLE
Fix indicatif compatibility with console

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ bytecount = "0.6.7"
 log = "0.4.19"
 pdf = "0.8.1"
 anyhow = "1.0.72"
-indicatif = "0.16.2"
+indicatif = "0.17.11"
 crossbeam = "0.8.2"
 clap = { version = "4.4.13", features = ["derive"] }
 colored = "2.0.4"

--- a/crates/cli-interface/src/lib.rs
+++ b/crates/cli-interface/src/lib.rs
@@ -61,9 +61,9 @@ fn wrapper(
     producer: Box<dyn Producer>,
 ) -> anyhow::Result<Option<Vec<u8>>> {
     let progress_bar = ProgressBar::new(producer.size() as u64);
-    progress_bar.set_draw_delta(1000);
-    progress_bar.set_style(ProgressStyle::default_bar()
-            .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} {percent}% {per_sec} ETA: {eta}"));
+    let style = ProgressStyle::default_bar()
+            .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} {percent}% {per_sec} ETA: {eta}")?;
+    progress_bar.set_style(style);
 
     // We're lucky. It appears ProgressBar does not call ProgressBar::finish(self) when dropped.
     let bar = progress_bar.clone();


### PR DESCRIPTION
Fix build error

<details>

<summary>Build logs</summary>

```shell
cargo build --release
    Updating `ustc` index
     Locking 2 packages to latest compatible versions
 Downgrading indicatif v0.18.0 -> v0.16.2 (available: v0.18.0)
      Adding number_prefix v0.4.0
   Compiling indicatif v0.16.2
error[E0432]: unresolved import `console::Term`
  --> /build/.cargo/registry/src/04b7754156161b43/indicatif-0.16.2/src/state.rs:10:5
   |
10 | use console::Term;
   |     ^^^^^^^^^^^^^ no `Term` in the root
   |
note: found an item that was configured out
  --> /build/.cargo/registry/src/04b7754156161b43/console-0.16.0/src/lib.rs:92:42
   |
92 |     user_attended, user_attended_stderr, Term, TermFamily, TermFeatures, TermTarget,
   |                                          ^^^^
note: the item is gated behind the `std` feature
  --> /build/.cargo/registry/src/04b7754156161b43/console-0.16.0/src/lib.rs:90:7
   |
90 | #[cfg(feature = "std")]
   |       ^^^^^^^^^^^^^^^
help: consider importing this variant instead
   |
10 - use console::Term;
10 + use crate::state::ProgressDrawTargetKind::Term;
   |

error[E0432]: unresolved imports `console::measure_text_width`, `console::Style`
  --> /build/.cargo/registry/src/04b7754156161b43/indicatif-0.16.2/src/style.rs:1:15
   |
1  | use console::{measure_text_width, Style};
   |               ^^^^^^^^^^^^^^^^^^  ^^^^^ no `Style` in the root
   |               |
   |               no `measure_text_width` in the root
   |
note: found an item that was configured out
  --> /build/.cargo/registry/src/04b7754156161b43/console-0.16.0/src/lib.rs:96:44
   |
96 |     colors_enabled, colors_enabled_stderr, measure_text_width, pad_str, pad_str_with,
   |                                            ^^^^^^^^^^^^^^^^^^
note: the item is gated behind the `std` feature
  --> /build/.cargo/registry/src/04b7754156161b43/console-0.16.0/src/lib.rs:94:7
   |
94 | #[cfg(feature = "std")]
   |       ^^^^^^^^^^^^^^^
note: found an item that was configured out
  --> /build/.cargo/registry/src/04b7754156161b43/console-0.16.0/src/lib.rs:98:19
   |
98 |     Color, Emoji, Style, StyledObject,
   |                   ^^^^^
note: the item is gated behind the `std` feature
  --> /build/.cargo/registry/src/04b7754156161b43/console-0.16.0/src/lib.rs:94:7
   |
94 | #[cfg(feature = "std")]
   |       ^^^^^^^^^^^^^^^

error[E0432]: unresolved imports `console::measure_text_width`, `console::Style`
  --> /build/.cargo/registry/src/04b7754156161b43/indicatif-0.16.2/src/utils.rs:7:15
   |
7  | use console::{measure_text_width, Style};
   |               ^^^^^^^^^^^^^^^^^^  ^^^^^ no `Style` in the root
   |               |
   |               no `measure_text_width` in the root
   |
note: found an item that was configured out
  --> /build/.cargo/registry/src/04b7754156161b43/console-0.16.0/src/lib.rs:96:44
   |
96 |     colors_enabled, colors_enabled_stderr, measure_text_width, pad_str, pad_str_with,
   |                                            ^^^^^^^^^^^^^^^^^^
note: the item is gated behind the `std` feature
  --> /build/.cargo/registry/src/04b7754156161b43/console-0.16.0/src/lib.rs:94:7
   |
94 | #[cfg(feature = "std")]
   |       ^^^^^^^^^^^^^^^
note: found an item that was configured out
  --> /build/.cargo/registry/src/04b7754156161b43/console-0.16.0/src/lib.rs:98:19
   |
98 |     Color, Emoji, Style, StyledObject,
   |                   ^^^^^
note: the item is gated behind the `std` feature
  --> /build/.cargo/registry/src/04b7754156161b43/console-0.16.0/src/lib.rs:94:7
   |
94 | #[cfg(feature = "std")]
   |       ^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0432`.
error: could not compile `indicatif` (lib) due to 3 previous errors
```

</details>