### PR TITLE
fix DefaultQuery

### DIFF
--- a/crates/producer/src/default_query.rs
+++ b/crates/producer/src/default_query.rs
@@ -63,7 +63,7 @@ impl Producer for DefaultQuery {
                 }
             }
         }
-        let return_value = std::mem::take(&mut self.current);
+        let return_value = self.current.clone();
         // For debugging and making sure all values are tried
         //match String::from_utf8(return_value.clone()) {
         //Ok(val)=>println!("Trying {}", val), _=>{}


### PR DESCRIPTION
std::mem::take(self.current) replaces self.current with the default value (0) and such renders successive calls invalid: Only the first call provides a correct attempt, all other return 0 instead and so the password can not be found.

The fix is to use self.current.clone() instead, as we need an independent copy that is going to get changed in-place